### PR TITLE
Update .gitattributes for detect correct repo language  

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 *.pyc 		binary
 *.pyd		binary
 *.pyo 		binary
+*.css linguist-language=Python
 
 # Note: .db, .p, and .pkl files are associated
 # with the python modules ``pickle``, ``dbm.*``,


### PR DESCRIPTION
Change repo language  to Python fro CSS
Repo was showing to CSS so Change it to python for other user to find it easily.